### PR TITLE
Revert "Support configuring consumers to start consuming from a specified ID"

### DIFF
--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	oldestId       = "0"
 	groupStartid   = ">"
 	redisBusyGroup = "BUSYGROUP Consumer Group name already exists"
 )
@@ -82,11 +83,6 @@ type SubscriberConfig struct {
 
 	// How long should we treat a consumer as offline
 	MaxIdleTime time.Duration
-
-	// Start consumption from the specified message ID
-	// When using "0", the consumer group will consume from the very first message
-	// When using "$", the consumer group will consume from the latest message
-	OldestId string
 }
 
 func (sc *SubscriberConfig) setDefaults() {
@@ -107,10 +103,6 @@ func (sc *SubscriberConfig) setDefaults() {
 	}
 	if sc.MaxIdleTime == 0 {
 		sc.MaxIdleTime = DefaultMaxIdleTime
-	}
-	// Consume from scratch by default
-	if sc.OldestId == "" {
-		sc.OldestId = "0"
 	}
 }
 
@@ -169,7 +161,7 @@ func (s *Subscriber) consumeMessages(ctx context.Context, topic string, output c
 	}()
 	if s.config.ConsumerGroup != "" {
 		// create consumer group
-		if _, err := s.client.XGroupCreateMkStream(ctx, topic, s.config.ConsumerGroup, s.config.OldestId).Result(); err != nil && err.Error() != redisBusyGroup {
+		if _, err := s.client.XGroupCreateMkStream(ctx, topic, s.config.ConsumerGroup, oldestId).Result(); err != nil && err.Error() != redisBusyGroup {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Reverts ThreeDotsLabs/watermill-redisstream#15 (CI failed)