### PR TITLE
fix prevent excessive output from abnormal connections

### DIFF
--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -315,6 +315,8 @@ func (s *Subscriber) read(ctx context.Context, stream string, readChannel chan<-
 			if err == redis.Nil {
 				continue
 			} else if err != nil {
+				// prevent excessive output from abnormal connections
+				time.Sleep(500 * time.Millisecond)
 				s.logger.Error("read fail", err, logFields)
 			}
 			if len(xss) < 1 || len(xss[0].Messages) < 1 {


### PR DESCRIPTION
When the redis service is abnormal, a large number of retries will be performed, resulting in a large number of input logs, cpu and I/O resources