### PR TITLE
Introduce FanOutOldestId setting for picking last message for fan-out

### DIFF
--- a/pkg/redisstream/pubsub_test.go
+++ b/pkg/redisstream/pubsub_test.go
@@ -181,7 +181,7 @@ func TestFanOut(t *testing.T) {
 			t.Fatal("msg nil")
 		}
 		t.Logf("subscriber 1: %v %v %v", msg.UUID, msg.Metadata, string(msg.Payload))
-		require.Equal(t, string(msg.Payload), "test"+strconv.Itoa(i))
+		require.Equal(t, "test"+strconv.Itoa(i), string(msg.Payload))
 		msg.Ack()
 	}
 	for i := 10; i < 50; i++ {
@@ -190,7 +190,7 @@ func TestFanOut(t *testing.T) {
 			t.Fatal("msg nil")
 		}
 		t.Logf("subscriber 2: %v %v %v", msg.UUID, msg.Metadata, string(msg.Payload))
-		require.Equal(t, string(msg.Payload), "test"+strconv.Itoa(i))
+		require.Equal(t, "test"+strconv.Itoa(i), string(msg.Payload))
 		msg.Ack()
 	}
 

--- a/pkg/redisstream/pubsub_test.go
+++ b/pkg/redisstream/pubsub_test.go
@@ -137,6 +137,7 @@ func TestFanOut(t *testing.T) {
 		SubscriberConfig{
 			Client:        redisClientOrFail(t),
 			Consumer:      watermill.NewShortUUID(),
+			OldestId:      "$",
 			ConsumerGroup: "",
 		},
 		watermill.NewStdLogger(true, false),
@@ -147,6 +148,7 @@ func TestFanOut(t *testing.T) {
 		SubscriberConfig{
 			Client:        redisClientOrFail(t),
 			Consumer:      watermill.NewShortUUID(),
+			OldestId:      "$",
 			ConsumerGroup: "",
 		},
 		watermill.NewStdLogger(true, false),

--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -263,7 +263,7 @@ func (s *Subscriber) read(ctx context.Context, stream string, readChannel chan<-
 	var (
 		streamsGroup = []string{stream, groupStartid}
 
-		fanOutStartid               = "$"
+		fanOutStartid               = s.config.OldestId
 		countFanOut   int64         = 0
 		blockTime     time.Duration = 0
 

--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -100,6 +100,11 @@ type SubscriberConfig struct {
 	// When using "$", the consumer group will consume from the latest message.
 	OldestId string
 
+	// If consumer group in not set, for fanout start consumption from the specified message ID.
+	// When using "0", the consumer group will consume from the very first message.
+	// When using "$", the consumer group will consume from the latest message.
+	FanOutOldestId string
+
 	// If this is set, it will be called to decide whether a pending message that
 	// has been idle for more than MaxIdleTime should actually be claimed.
 	// If this is not set, then all pending messages that have been idle for more than MaxIdleTime will be claimed.
@@ -142,6 +147,10 @@ func (sc *SubscriberConfig) setDefaults() {
 	// Consume from scratch by default
 	if sc.OldestId == "" {
 		sc.OldestId = "0"
+	}
+
+	if sc.FanOutOldestId == "" {
+		sc.FanOutOldestId = "$"
 	}
 }
 
@@ -263,7 +272,7 @@ func (s *Subscriber) read(ctx context.Context, stream string, readChannel chan<-
 	var (
 		streamsGroup = []string{stream, groupStartid}
 
-		fanOutStartid               = s.config.OldestId
+		fanOutStartid               = s.config.FanOutOldestId
 		countFanOut   int64         = 0
 		blockTime     time.Duration = 0
 


### PR DESCRIPTION
Perhaps it makes more sense to allow customisation in fan-out setting? 

For example in my case I built a service which has to consume whole stream each time it restarts (it maintains an in-memory read model). I can do that with consumer groups but that does seem to be a good fit for my case

PS. Though it breaks a default behaviour, since by default OldestId is `$` :/ I guess the only way out here would a creation of additional configuration parameter ...