### PR TITLE
ack invalid messages

### DIFF
--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -424,7 +424,11 @@ OUTER_LOOP:
 					MinIdle:  s.config.MaxIdleTime,
 					Messages: []string{xp.ID},
 				}).Result()
-				if err != nil {
+				if err == redis.Nil {
+					// Any messages that are nil, should be xacked and skipped
+					s.client.XAck(ctx, stream, s.config.ConsumerGroup, xp.ID)
+					continue
+				} else if err != nil {
 					s.logger.Error(
 						"xclaim fail",
 						err,


### PR DESCRIPTION
Messages that are left in a pending state will eventually be deleted.  Processing these messages triggers an error, and so they are never discarded, even though they have no content anymore.  We are running AWS Elasticache Redis 6.2.6

When the xclaimed messages are fetched with XGET, I can see that the error value is `redis: nil`

```
error -- redis: nil
xp -- {
        Consumer: dispatcher-7f7684b54f-etecce
        ID: 1722875908017-0
        Idle: 1020707000000
        RetryCount: 1427
      }
```

What is happening is that the message exists in the PEL but has no content because it was deleted. Acking the message removes it from the PEL so it won't be claimed again in the same consumer group.

I have tried to create a test that gets the queue in this state, but didn't succeed.  I tested this patch against our staging systems, and it did succeed at draining the queue.