### PR TITLE
Unmarshaller more resiliant and clearer error if uuid header is missing

### DIFF
--- a/pkg/redisstream/marshaller.go
+++ b/pkg/redisstream/marshaller.go
@@ -46,7 +46,17 @@ func (DefaultMarshallerUnmarshaller) Marshal(_ string, msg *message.Message) (ma
 }
 
 func (DefaultMarshallerUnmarshaller) Unmarshal(values map[string]interface{}) (msg *message.Message, err error) {
-	msg = message.NewMessage(values[UUIDHeaderKey].(string), []byte(values["payload"].(string)))
+	var uuid, payload any
+	uuid, payload = values[UUIDHeaderKey], values["payload"]
+	if uuid == nil {
+		return nil, errors.Errorf("%s key is missing as part of the message", UUIDHeaderKey)
+	}
+
+	if payload == nil {
+		payload = ""
+	}
+
+	msg = message.NewMessage(uuid.(string), []byte(payload.(string)))
 
 	md := values["metadata"]
 	if md != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

I was having issues testing the application using default marshaller and setting the whole thing up as a subscriber listening to a topic and trying to send messages using redis-cli by hand. The thing is that I wasn't sending any uuid header and there wasn't an explicit error in the code to let me know what was happening so I added because I think it is for a better understanding to everyone who try this application that way. 

### Details

<!-- Describe how you solved the problem or implemented the feature. -->
Inside marshaller.go archive, the one that is used as a DefaultMarshaller, inside Unmarshall function, there was an explicit conversion of an interface type variable to a string for an UUID header value and also the payload of the message. I know the marshaller is really basic and it is advisable to use a custom one but I think is clearer for testing purposes if it is added a little `if` as a check to see if UUID header has been sent in order to warn the user if not and to give "payload" a base value in case it is empty because it will panic otherwise because of a forced nil conversion into a string value. 

### Alternative approaches considered (if applicable)

<!-- If applicable, describe alternative approaches you considered and why you chose this one. -->

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
