### PR TITLE
Add ability to disable indefinite initial block in reader goroutine

### DIFF
--- a/pkg/redisstream/pubsub_test.go
+++ b/pkg/redisstream/pubsub_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -630,4 +631,67 @@ func TestSubscriber_Read(t *testing.T) {
 		require.NoError(t, sub.Close())
 	})
 
+	t.Run("With DisableIndefiniteInitialBlock", func(t *testing.T) {
+		t.Parallel()
+
+		topic := watermill.NewShortUUID()
+		consumerGroup := watermill.NewShortUUID()
+		consumer := watermill.NewShortUUID()
+
+		cases := []struct {
+			name                  string
+			expectedBlockedClient bool
+		}{
+			{
+				name:                  "should have blocked client",
+				expectedBlockedClient: true,
+			},
+			{
+				name:                  "should not have blocked client",
+				expectedBlockedClient: false,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				rdb := redisClientOrFail(t)
+				sub, err := NewSubscriber(SubscriberConfig{
+					Client:                        rdb,
+					ConsumerGroup:                 consumerGroup,
+					Consumer:                      consumer,
+					DisableIndefiniteInitialBlock: !tc.expectedBlockedClient,
+					BlockTime:                     200 * time.Millisecond,
+				}, nil)
+				require.NoError(t, err)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				_, err = sub.Subscribe(ctx, topic)
+				require.NoError(t, err)
+
+				// wait for all background goroutines to kick off
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+				// wait for a blocking time to pass, if applicable
+				time.Sleep(120 * time.Millisecond)
+
+				res, err := rdb.ClientList(context.Background()).Result()
+				require.NoError(t, err)
+
+				require.Equal(t, tc.expectedBlockedClient, checkBlockedClients(res))
+
+				require.NoError(t, sub.Close())
+			})
+		}
+	})
+}
+
+func checkBlockedClients(clientsString string) bool {
+	clients := strings.Split(clientsString, "\n")
+	for _, client := range clients {
+		if strings.Contains(client, "flags=b") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/redisstream/subscriber.go
+++ b/pkg/redisstream/subscriber.go
@@ -119,6 +119,13 @@ type SubscriberConfig struct {
 	// should return the read method and close the subscriber or just log the error
 	// and continue.
 	ShouldStopOnReadErrors func(error) bool
+
+	// If this set to true, the initial call to XRead* will block using BlockTime configuration setting.
+	// By default, the initial XRead* call is blocking indefinitely (timeout=0), which may lead to reader goroutine leak
+	// in case there are no messages in the stream.
+	// Context cancellation does not work due to the way go-redis handles connection management.
+	// For more information, see https://github.com/redis/go-redis/issues/2556.
+	DisableIndefiniteInitialBlock bool
 }
 
 func (sc *SubscriberConfig) setDefaults() {
@@ -285,6 +292,10 @@ func (s *Subscriber) read(ctx context.Context, stream string, readChannel chan<-
 		xs  *redis.XStream
 		err error
 	)
+
+	if s.config.DisableIndefiniteInitialBlock {
+		blockTime = s.config.BlockTime
+	}
 
 	if s.config.ConsumerGroup != "" {
 		// 1. get pending message from idle consumer


### PR DESCRIPTION

<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

This PR provides a way to overcome the issue https://github.com/ThreeDotsLabs/watermill/issues/640

In this PR the new `DisableIndefiniteInitialBlock` SubscriberConfig setting is added. The type for this setting is `bool`.

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

### Details

<!-- Describe how you solved the problem or implemented the feature. -->

If the `DisableIndefiniteInitialBlock`, the initial call to `XRead*` will be set as `BlockTime` config setting. This will allow callers of `Subscribe` function make sure the reader goroutine exits in the case of the context cancellation. Otherwise, in case there is no data in the stream and the caller cancel's the context, the reader goroutine will be active hence leaking.

In `go-redis` the context cancellation for blocking operations does not work (issue https://github.com/redis/go-redis/issues/2556).

### Alternative approaches considered (if applicable)

<!-- If applicable, describe alternative approaches you considered and why you chose this one. -->

Alternative, we could set the blockTime as `config.BlockTIme` by default, but this would change the current behavior and existing clients may experience an unexpected surge of requests to Redis with `XRead*` operations. 

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [x] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
